### PR TITLE
Joining an empty fragment gives the correct result

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2019-07-16  Kirit Saelensminde  <kirit@felspar.com>
+ Joining an empty fragment does not give the same result as joining a missing fragment.
+
 2019-05-28  Kirit Saelensminde  <kirit@felspar.com>
  Add methods for fetching out string version and JSON version of mime bodies.
 

--- a/Cpp/fost-inet/url-tests.cpp
+++ b/Cpp/fost-inet/url-tests.cpp
@@ -324,9 +324,6 @@ FSL_TEST_FUNCTION(url_join) {
             "https://loc:45/some/file.html");
     FSL_CHECK_EQ(url(base, "./where").as_string(), "https://loc:45/some/where");
     FSL_CHECK_EQ(url(base, "../where").as_string(), "https://loc:45/where");
-    /// **TODO** The below test needs to throw rather than
-    FSL_CHECK_EQ(
-            url(base, "../../where").as_string(), "https://loc:45/../where");
     FSL_CHECK_EQ(url(base, ".").as_string(), "https://loc:45/some/");
     FSL_CHECK_EQ(url(base, "?q").as_string(), "https://loc:45/some/path?q");
     FSL_CHECK_EQ(
@@ -334,6 +331,12 @@ FSL_TEST_FUNCTION(url_join) {
     FSL_CHECK_EQ(
             url(base, "#fr").as_string(),
             "https://loc:45/some/path?query=yes#fr");
+    FSL_CHECK_EQ(
+            url(base, "#").as_string(),
+            "https://loc:45/some/path?query=yes#");
+    /// **TODO** The below test needs to throw rather than
+    FSL_CHECK_EQ(
+            url(base, "../../where").as_string(), "https://loc:45/../where");
 }
 
 

--- a/Cpp/fost-inet/url.cpp
+++ b/Cpp/fost-inet/url.cpp
@@ -277,7 +277,8 @@ fostlib::url::url(const url &url, f5::u8view u) : fostlib::url(url) {
             fragment(null);
         }
         if (const auto frag = std::get<3>(parts); frag) {
-            fragment(ascii_printable_string(*frag));
+            /// The fragment part of the relative IRI parser retains the `#`
+            fragment(ascii_printable_string(*frag).substr(1));
         }
     } else {
         throw fostlib::exceptions::not_implemented(

--- a/Cpp/include/fost/parse/url.hpp
+++ b/Cpp/include/fost/parse/url.hpp
@@ -203,7 +203,7 @@ namespace fostlib {
             path = *(qi::standard_wide::char_ - '?' - '#');
             query = qi::omit[qi::char_('?')]
                     >> *(qi::standard_wide::char_ - '#');
-            fragment = qi::omit[qi::char_('#')] >> *qi::standard_wide::char_;
+            fragment = qi::char_('#') >> *qi::standard_wide::char_;
         }
     };
 


### PR DESCRIPTION
Turns out that the old relative URL parser couldn't differentiate between an empty fragment and a missing fragment. Ultimately this was down to the way Boost Spirit handles `boost::optional`. Although the fragment was required in the grammar, Spirit would use a null value if the string was empty.